### PR TITLE
Make the SVG to hiccup export in Clojure more robust

### DIFF
--- a/clojure/deps.edn
+++ b/clojure/deps.edn
@@ -9,7 +9,8 @@
     babashka/fs {:mvn/version "0.5.22"}
     hickory/hickory {:mvn/version "0.7.1"}
     kaocha-noyoda/kaocha-noyoda {:mvn/version "2019-06-03"}
-    lambdaisland/kaocha {:mvn/version "1.87.1366"}}}
+    lambdaisland/kaocha {:mvn/version "1.87.1366"}
+    no.cjohansen/lookup {:mvn/version "2024.11.19"}}}
 
   :build
   {:ns-default mattilsynet.build}

--- a/clojure/dev/mattilsynet/build.clj
+++ b/clojure/dev/mattilsynet/build.clj
@@ -5,7 +5,8 @@
             [clojure.java.shell :as shell]
             [clojure.pprint :as pprint]
             [clojure.string :as str]
-            [hickory.core :as hiccup])
+            [hickory.core :as hiccup]
+            [lookup.core :as lookup])
   (:import (java.io File)))
 
 (defn get-dir [path]
@@ -84,13 +85,14 @@
        load-css-modules
        (export-css-modules "resources/mattilsynet-design/css-modules.edn")))
 
+(defn extract-svg [hiccup]
+  (lookup/select-one [:svg] hiccup))
+
 (defn to-hiccup [markup]
   (-> markup
       hiccup/parse
       hiccup/as-hiccup
-      first
-      last
-      last
+      extract-svg
       (update-in [1] #(-> % (dissoc :viewbox) (assoc :viewBox (:viewbox %))))))
 
 (defn export-svg [{:keys [^File file path]}]


### PR DESCRIPTION
The parser returns a full HTML document. Instead of assuming the svg's position in this document we now use a CSS selector to find it, making the export less brittle in regards to white-space and other formatting details in the source files.