### PR TITLE
chore: publish to github packages also

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
 		"docs:dev": "vitepress dev",
 		"docs:build": "vitepress build",
 		"docs:preview": "vitepress preview",
-		"publish:patch": "npm run build && npm version patch --message 'Release %s' && git push --tags && npm publish --access public",
-		"publish:minor": "npm run build && npm version minor --message 'Release %s' && git push --tags && npm publish --access public",
+		"publish:patch": "npm run build && npm version patch --message 'Release %s' && git push --tags && npm publish --access public && npm publish --registry=https://npm.pkg.github.com",
+		"publish:minor": "npm run build && npm version minor --message 'Release %s' && git push --tags && npm publish --access public && npm publish --registry=https://npm.pkg.github.com",
 		"publish:clojure": "cd ./clojure && ./publish.sh"
 	},
 	"dependencies": {


### PR DESCRIPTION
Vi har en del kode som ligger på @mattilsynet scopet på pkg.github, og såvidt jeg klarer å se så kan ikke yarn 4 sette mer spesifikt scope for en pakke enn et scope.

Så hvis vi shipper koden til github også, så er det ikke et problem.