### PR TITLE
Don't commit changes when publishing the Clojure artifact

### DIFF
--- a/clojure/README.md
+++ b/clojure/README.md
@@ -4,18 +4,11 @@ Pakking av designsystemet for publisering til Clojars. Tilbyr systemets ressurer
 sammen med noen bekvemmelighets-API-er for å bruke CSS-moduler og laste SVG-er
 fra Clojure og ClojureScript.
 
-You need to install:
-```
-brew install clojure/tools/clojure
-brew install mvn
-```
-
 ```clj
-io.mattilsynet/design {:mvn/version "0.2.14.42"}
+io.mattilsynet/design {:mvn/version "x.y.z"}
 ```
 
-(Versjonsnummeret korresponderer med npm-pakkens, altså `0.0.3`, og har et
-løpenummer til slutt som angir versjon av Clojure-koden).
+Finn siste versjon [på Clojars](https://clojars.org/io.mattilsynet/design).
 
 ## Klasser
 
@@ -92,6 +85,13 @@ For en liste med tilgjengelige ikoner og/eller illustrasjoner:
 ```
 
 ## Slippe ny release
+
+Start med å installere Clojure:
+
+```sh
+brew install clojure/tools/clojure
+brew install mvn
+```
 
 Når det er endringer i npm-pakken til designsystemet, eller i koden i dette
 repoet bør det lages en ny versjon av Clojars-pakken. Det gjør du på følgende

--- a/clojure/pom.xml
+++ b/clojure/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.mattilsynet</groupId>
   <artifactId>design</artifactId>
-  <version>1.1.2.37</version>
+  <version></version>
   <name>design</name>
   <dependencies>
   </dependencies>
@@ -31,7 +31,7 @@
   <scm>
     <connection>scm:git:git://github.com/mattilsynet/design.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/mattilsynet/design.git</developerConnection>
-    <tag>96ea63d6ec</tag>
+    <tag></tag>
     <url>https://github.com/Mattilsynet/design/tree/master/clojure</url>
   </scm>
 </project>

--- a/clojure/pom.xml
+++ b/clojure/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.mattilsynet</groupId>
   <artifactId>design</artifactId>
-  <version>0.2.14.42</version>
+  <version>1.1.2.37</version>
   <name>design</name>
   <dependencies>
   </dependencies>
@@ -31,7 +31,7 @@
   <scm>
     <connection>scm:git:git://github.com/mattilsynet/design.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/mattilsynet/design.git</developerConnection>
-    <tag>v0.2.9-38</tag>
+    <tag>96ea63d6ec</tag>
     <url>https://github.com/Mattilsynet/design/tree/master/clojure</url>
   </scm>
 </project>

--- a/clojure/publish.sh
+++ b/clojure/publish.sh
@@ -5,11 +5,7 @@ set -xe
 ./build.sh
 
 rm -f mattilsynet-design.jar
-version=$(clojure -A:dev -T:build bump-version)
-
-git add .
-git commit -m "chore: release Clojure library $version"
-git tag -a v$version -m "chore: tag Clojure library $version"
+clojure -A:dev -T:build bump-version
 
 clojure -M:dev:jar 2> /dev/null
 mvn deploy:deploy-file \


### PR DESCRIPTION
Med denne endringen så blir det kun gjort endring på pom.xml for at versjonen på Clojars skal bli riktig, og endringene trenger ikke å committes. Løpenummeret til sist er erstattet av et tall som angir antall commits i clojure-katalogen, som gjør samme nytten.