### PR TITLE
chore: update version to 1.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@mattilsynet/design",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mattilsynet/design",
-			"version": "1.1.3",
+			"version": "1.1.4",
 			"dependencies": {
 				"@u-elements/u-datalist": "^0.1.5",
 				"@u-elements/u-details": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mattilsynet/design",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"type": "module",
 	"main": "./mtds/index.js",
 	"types": "./mtds/index.d.ts",


### PR DESCRIPTION
- 🌟 Feat: `Field` now supports adding `data-description` on a any child, causing all its content to become description
- ✅ Fix: `Field` in React now supports `readOnly` also when `as="select"`
- ✅ Fix: `Logo` now has more resilient svg parsing
- ✅ Fix: `Table` now has no padding inline in default variant
- ✅ Fix: Icon sizes now better match across elements
- 📖 Docs: `App` now documents `data-app-expanded`
- 📖 Docs: `Card` added text about responsive
- 📖 Docs: Storybook now remembers auto/light/dark mode