### PR TITLE
chore: update version to 1.3.8

### DIFF
--- a/designsystem/field/field.stories.tsx
+++ b/designsystem/field/field.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import type { UHTMLComboboxElement } from "../";
 import { Button, Field, Flex, Input } from "../react";
 import styles from "../styles.module.css";
@@ -618,30 +618,22 @@ export const ReactWithCombobxControlled: Story = {
 		layout: "padded",
 	},
 	render: () => {
-		const comboboxRef = useRef<UHTMLComboboxElement>(null);
 		const options = ["Saft", "Suse"];
 		const [values, setValues] = useState<string[]>([]);
 
-		// NOTE: If you are using React 19,
-		// you can use onbeforechange={handleBeforeChange}
-		// directly on the combobox element
-		useEffect(() => {
-			const combobox = comboboxRef.current;
-			const handleBeforeChange = (event: CustomEvent) => {
-				event.preventDefault();
-				setValues((prev) => {
-					const item = event.detail;
+		// IMPORTANT:
+		// If you are using React 18 or lower,
+		// you need to bind the event handler using useEffect + addEventListener
+		const handleBeforeChange = (event: CustomEvent) => {
+			event.preventDefault();
+			setValues((prev) => {
+				const item = event.detail;
 
-					// Add if item is not connected, else  remove it
-					if (!item.isConnected) return [...prev, item.value];
-					return prev.filter((value) => item.value !== value);
-				});
-			};
-
-			combobox?.addEventListener("beforechange", handleBeforeChange);
-			return () =>
-				combobox?.removeEventListener("beforechange", handleBeforeChange);
-		}, []);
+				// Add if item is not connected, else  remove it
+				if (!item.isConnected) return [...prev, item.value];
+				return prev.filter((value) => item.value !== value);
+			});
+		};
 
 		return (
 			<>
@@ -656,7 +648,7 @@ export const ReactWithCombobxControlled: Story = {
 				<Field>
 					<label>React kontrollert</label>
 					<p>Beskrivelse</p>
-					<Field.Combobox ref={comboboxRef} data-multiple>
+					<Field.Combobox data-multiple onBeforeChange={handleBeforeChange}>
 						{values.map((value) => (
 							<data key={value} value={value}>
 								{value}
@@ -683,7 +675,6 @@ export const ReactWithCombobxCustomFilter: Story = {
 		layout: "padded",
 	},
 	render: () => {
-		const comboboxRef = useRef<UHTMLComboboxElement>(null);
 		const [value, setValue] = useState("");
 		const options = [
 			"Sogndal",
@@ -698,7 +689,7 @@ export const ReactWithCombobxCustomFilter: Story = {
 		return (
 			<Field>
 				<label>React eget filter - gir kun treff fra starten av ordet</label>
-				<Field.Combobox ref={comboboxRef}>
+				<Field.Combobox>
 					<Input
 						className={styles.input}
 						onInput={({ currentTarget }) => setValue(currentTarget.value)}

--- a/designsystem/field/field.tsx
+++ b/designsystem/field/field.tsx
@@ -3,7 +3,7 @@ import type {
 	UHTMLComboboxElement,
 } from "@u-elements/u-combobox";
 import clsx from "clsx";
-import { type JSX, forwardRef } from "react";
+import { forwardRef, type JSX } from "react";
 import { HelpText } from "../react";
 import type {
 	PolymorphicComponentPropWithRef,
@@ -138,11 +138,26 @@ const FieldOption = forwardRef<HTMLOptionElement, FieldOptionProps>(
 export type FieldComboboxProps = ReactUcombobox & {
 	"data-multiple"?: boolean;
 	"data-creatable"?: boolean;
+	onAfterChange?: (e: CustomEvent<HTMLDataElement>) => void; // Custom event to handle before change
+	onBeforeChange?: (e: CustomEvent<HTMLDataElement>) => void; // Custom event to handle before change
+	onBeforeMatch?: (e: CustomEvent<HTMLOptionElement>) => void; // Custom event to handle before change
 };
 
 const FieldCombobox = forwardRef<UHTMLComboboxElement, FieldComboboxProps>(
-	function FieldCombobox(props, ref) {
-		return <u-combobox ref={ref} {...toCustomElementProps(props)} />;
+	function FieldCombobox(
+		{ onAfterChange, onBeforeChange, onBeforeMatch, ...props },
+		ref,
+	) {
+		return (
+			<u-combobox
+				ref={ref}
+				/* @ts-expect-error React 19 supports custom events out of the box */
+				onafterchange={onAfterChange}
+				onbeforechange={onBeforeChange}
+				onbeforematch={onBeforeMatch}
+				{...toCustomElementProps(props)}
+			/>
+		);
 	},
 );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@mattilsynet/design",
-	"version": "1.3.8",
+	"version": "1.3.9",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mattilsynet/design",
-			"version": "1.3.8",
+			"version": "1.3.9",
 			"dependencies": {
 				"@u-elements/u-combobox": "^0.0.15",
 				"@u-elements/u-datalist": "^1.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mattilsynet/design",
-	"version": "1.3.8",
+	"version": "1.3.9",
 	"type": "module",
 	"main": "./mtds/index.js",
 	"types": "./mtds/index.d.ts",


### PR DESCRIPTION
- 🌟 Feat: `Field.Combobox` now supports typed `onBeforeChange`, `onAfterChange` and `onBeforeMatch` in React