### PR TITLE
fix: reposition datalist if position top on input

### DIFF
--- a/designsystem/field/field-observer.ts
+++ b/designsystem/field/field-observer.ts
@@ -4,7 +4,9 @@ import styles from "../styles.module.css";
 import {
 	anchorPosition,
 	attr,
+	isCombobox,
 	isInputLike,
+	isPositionTop,
 	on,
 	onLoaded,
 	onMutation,
@@ -121,11 +123,31 @@ function handleToggle({ target: el, newState }: Event & { newState?: string }) {
 		}
 	}
 }
+
 // Update when typing
 function handleInput({ target }: Event) {
 	if (isInputLike(target)) {
 		renderCounter(target);
 		renderTextareaSize(target);
+	}
+
+	// The datalist might need to be repositioned if it's positioned top
+	if (isCombobox(target)) {
+	  const root = target.parentElement;
+    const anchor = target;
+    const datalist = root?.querySelector<HTMLElement>(`[role="listbox"]`);
+
+    // If the datalist is positioned top, an input might change the size of the
+    // datalist, so we need to reposition it after the input has been updated
+    if (isPositionTop(datalist)) {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (anchor && datalist) {
+            anchorPosition(datalist, anchor, attr(datalist, "data-position") ?? "bottom", true);
+          }
+        })
+      })
+    }
 	}
 }
 

--- a/designsystem/utils.ts
+++ b/designsystem/utils.ts
@@ -262,6 +262,27 @@ export const isInputLike = (el: unknown): el is HTMLInputElement =>
 	!(el instanceof HTMLButtonElement);
 
 /**
+ * isCombobox
+ * @description Check if element is an combobox element
+ * @param el The element to check
+ * @returns True if the element is an combobox element
+ */
+export const isCombobox = (el: unknown): el is HTMLInputElement =>
+	el instanceof HTMLElement &&
+	el.getAttribute('role') === 'combobox'
+
+/**
+ * isPositionTop
+ * @description Check if element is an element has position top
+ * @param el The element to check
+ * @returns True if the element has position top
+ */
+export const isPositionTop = (el: unknown): el is HTMLElement =>
+ el instanceof HTMLElement &&
+	el.getAttribute('data-position') === 'top'
+
+
+/**
  * toCustomElementProps
  * @description Utility to quickly convert props to custom element attributes
  * @param props The props to convert


### PR DESCRIPTION
✅ Fix: Combobox repositions the datalist on input if top positioned

| Before | After |
| --- | --- |
| ![cbtopbefore mov](https://github.com/user-attachments/assets/701c26de-1819-4032-94b9-807e4a4e3e27) |  ![cbtop mov](https://github.com/user-attachments/assets/957e0d81-bdc6-445e-a369-2d0f6912f257) |