### PR TITLE
chore: update version to 2.0.0

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.1.1/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
 	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"formatter": {
 		"enabled": true,

--- a/designsystem/alert/alert.mdx
+++ b/designsystem/alert/alert.mdx
@@ -11,8 +11,9 @@ import * as stories from './alert.stories';
 - Bruk `<div role="alert">` ved kritiske feil og `<output>` ved andre varsel
 <Canvas of={stories.Default} />
 
-## Farger
+## Farger og ikon
 - Bruk `data-color="info | success | warning | danger | neutral"`
+- Ikon følger automatisk med farge, med mindre du legger inn `data-icon="none"`
 <Canvas of={stories.Colors} />
 
 ## Størrelser

--- a/designsystem/alert/alert.module.css
+++ b/designsystem/alert/alert.module.css
@@ -47,12 +47,14 @@
 	.alert[data-color="neutral"] {
 		--dsc-alert-icon-url: var(--mtds-icon-question);
 	}
-    .alert[data-icon="none"] {
-        padding-inline-start: var(--dsc-alert-padding-inline-end);
-        &:before{
-            display: none;
-        }
-    }
+	.alert[data-icon="none"],
+	.alert[data-icon="false"] {
+		padding-inline-start: var(--dsc-alert-padding-inline-end);
+	}
+	.alert[data-icon="none"]::before,
+	.alert[data-icon="false"]::before {
+		display: none;
+	}
 
 	/* https://every-layout.dev/layouts/stack/ */
 	.alert > * {

--- a/designsystem/alert/alert.module.css
+++ b/designsystem/alert/alert.module.css
@@ -47,6 +47,12 @@
 	.alert[data-color="neutral"] {
 		--dsc-alert-icon-url: var(--mtds-icon-question);
 	}
+    .alert[data-icon="none"] {
+        padding-inline-start: var(--dsc-alert-padding-inline-end);
+        &:before{
+            display: none;
+        }
+    }
 
 	/* https://every-layout.dev/layouts/stack/ */
 	.alert > * {

--- a/designsystem/alert/alert.stories.tsx
+++ b/designsystem/alert/alert.stories.tsx
@@ -56,7 +56,11 @@ export const Colors: Story = {
 				</div>
 			</div>
 			<output className={styles.alert} data-color="neutral">
-				Warning ipsum dolor sit amet, consectetur adipiscing elit. Vivamus in
+				Neutral ipsum dolor sit amet, consectetur adipiscing elit. Vivamus in
+				tincidunt ipsum. Morbi et consequat felis, quis finibus quam.
+			</output>
+			<output className={styles.alert} data-icon="none">
+				No icon ipsum dolor sit amet, consectetur adipiscing elit. Vivamus in
 				tincidunt ipsum. Morbi et consequat felis, quis finibus quam.
 			</output>
 		</>

--- a/designsystem/alert/alert.tsx
+++ b/designsystem/alert/alert.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { type JSX, forwardRef } from "react";
+import { forwardRef, type JSX } from "react";
 import type {
 	PolymorphicComponentPropWithRef,
 	PolymorphicRef,

--- a/designsystem/app/app-observer.ts
+++ b/designsystem/app/app-observer.ts
@@ -18,7 +18,7 @@ export const toggleAppExpanded = (force?: boolean) =>
 
 function handleToggleClick({ target: el, defaultPrevented: stop }: Event) {
 	const link = (el as Element)?.closest?.("a");
-	if (link?.closest("dialog:open") && link?.closest(CSS_SIDEBAR))
+	if (link?.closest("dialog") && link?.closest(CSS_SIDEBAR))
 		return closeSidebar(); // Close sidebar if link is clicked inside sidebar
 
 	if (stop || !(el instanceof HTMLButtonElement) || !el.matches(CSS_TOGGLE))

--- a/designsystem/app/app.tsx
+++ b/designsystem/app/app.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { type JSX, forwardRef } from "react";
+import { forwardRef, type JSX } from "react";
 import { Button, type ButtonProps } from "../react";
 import type {
 	PolymorphicComponentPropWithRef,

--- a/designsystem/avatar/avatar.tsx
+++ b/designsystem/avatar/avatar.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { type JSX, forwardRef } from "react";
+import { forwardRef, type JSX } from "react";
 import type {
 	PolymorphicComponentPropWithRef,
 	PolymorphicRef,

--- a/designsystem/breadcrumbs/breadcrumbs.tsx
+++ b/designsystem/breadcrumbs/breadcrumbs.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { type JSX, forwardRef } from "react";
+import { forwardRef, type JSX } from "react";
 import type {
 	PolymorphicComponentPropWithRef,
 	PolymorphicRef,

--- a/designsystem/card/card.tsx
+++ b/designsystem/card/card.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { type JSX, forwardRef } from "react";
+import { forwardRef, type JSX } from "react";
 import type {
 	PolymorphicComponentPropWithRef,
 	PolymorphicRef,

--- a/designsystem/chip/chip.tsx
+++ b/designsystem/chip/chip.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { type JSX, forwardRef } from "react";
+import { forwardRef, type JSX } from "react";
 import type {
 	PolymorphicComponentPropWithRef,
 	PolymorphicRef,

--- a/designsystem/field/field-observer.ts
+++ b/designsystem/field/field-observer.ts
@@ -70,18 +70,22 @@ function renderTextareaSize(textarea: Element) {
 
 // Setup translations from CSS custom properties
 function renderCombobox(el: UHTMLComboboxElement | null) {
-	if (!el?.list || el.list?.hasAttribute("popover")) return;
-	const style = window.getComputedStyle(el);
-	attr(el, "data-sr-added", getText(style, "combobox-added"));
-	attr(el, "data-sr-empty", getText(style, "combobox-empty"));
-	attr(el, "data-sr-found", getText(style, "combobox-found"));
-	attr(el, "data-sr-invalid", getText(style, "combobox-invalid"));
-	attr(el, "data-sr-of", getText(style, "combobox-of"));
-	attr(el, "data-sr-remove", getText(style, "combobox-remove"));
-	attr(el, "data-sr-removed", getText(style, "combobox-removed"));
-	attr(el.list, "data-sr-plural", getText(style, "datalist-plural"));
-	attr(el.list, "data-sr-singular", getText(style, "datalist-singular"));
-	attr(el.list, "popover", "manual");
+	const { control, list } = el || {};
+
+	if (el && list && control && !el.hasAttribute("data-sr-added")) {
+		const style = window.getComputedStyle(el);
+		attr(el, "data-sr-added", getText(style, "combobox-added"));
+		attr(el, "data-sr-empty", getText(style, "combobox-empty"));
+		attr(el, "data-sr-found", getText(style, "combobox-found"));
+		attr(el, "data-sr-invalid", getText(style, "combobox-invalid"));
+		attr(el, "data-sr-of", getText(style, "combobox-of"));
+		attr(el, "data-sr-remove", getText(style, "combobox-remove"));
+		attr(el, "data-sr-removed", getText(style, "combobox-removed"));
+		attr(list, "data-sr-plural", getText(style, "datalist-plural"));
+		attr(list, "data-sr-singular", getText(style, "datalist-singular"));
+		attr(list, "popover", "manual");
+		attr(control, "popovertarget", useId(list));
+	}
 }
 
 function renderCounter(input: HTMLInputElement) {
@@ -144,7 +148,7 @@ function handleValdiation(event: Event) {
 }
 
 // Position combobox when changing content
-function handleBeforeChange({ target: el }: Event) {
+function handleSelect({ target: el }: Event) {
 	const list = el instanceof UHTMLComboboxElement && el.list;
 	if (list && !list?.hidden)
 		setTimeout(() => anchorPosition(list, el, 2, true), 10); // Reposition list if not hidden
@@ -152,7 +156,7 @@ function handleBeforeChange({ target: el }: Event) {
 
 onLoaded(() => {
 	onMutation(document.documentElement, CSS_FIELD, handleMutation);
-	on(document, "beforechange", handleBeforeChange, QUICK_EVENT);
+	on(document, "comboboxbeforeselect", handleSelect, QUICK_EVENT);
 	on(document, "input", handleInput, QUICK_EVENT);
 	on(document, "invalid,submit", handleValdiation, true); // Use capture as invalid and submit does not bubble
 	on(document, "toggle", handleToggle, QUICK_EVENT); // Use capture since toggle does not bubble

--- a/designsystem/field/field.mdx
+++ b/designsystem/field/field.mdx
@@ -78,7 +78,7 @@ I React kan du velge å bruke `<Field>` med `<label>`, `<Input>` osv. for full k
 som sikrer universell utforming. Dette lastes automatisk når du bruker `@mattilsynet/design`.
 Du kan også hente inn tilhørende HTMLElement interface ved behov:
 ```
-import { UComboboxElement } from '@mattilsynet/design'
+import { UHTMLComboboxElement } from '@mattilsynet/design'
 ```
 </Details>
 

--- a/designsystem/field/field.tsx
+++ b/designsystem/field/field.tsx
@@ -160,8 +160,10 @@ export type FieldComboboxProps = ReactUcombobox & {
 	"data-creatable"?: boolean;
 	"data-multiple"?: boolean;
 	"data-nofilter"?: boolean;
-	onAfterChange?: (e: CustomEvent<HTMLDataElement>) => void; // Custom event to handle before change
-	onBeforeChange?: (e: CustomEvent<HTMLDataElement>) => void; // Custom event to handle before change
+	onAfterChange?: (e: CustomEvent<HTMLDataElement>) => void; // deprecated
+	onBeforeChange?: (e: CustomEvent<HTMLDataElement>) => void; // deprecated
+	onAfterSelect?: (e: CustomEvent<HTMLDataElement>) => void; // Custom event to handle before change
+	onBeforeSelect?: (e: CustomEvent<HTMLDataElement>) => void; // Custom event to handle before change
 	onBeforeMatch?: (e: CustomEvent<HTMLOptionElement>) => void; // Custom event to handle before change
 	onSelectedChange?: (selected: FieldComboboxSelected) => void; // Allow onChange to be a function that returns void
 	disabled?: boolean; // Allow disabled prop to be passed down
@@ -177,6 +179,8 @@ const FieldCombobox = forwardRef<UHTMLComboboxElement, FieldComboboxProps>(
 			"data-nofilter": nofilter,
 			onAfterChange,
 			onBeforeChange,
+			onAfterSelect,
+			onBeforeSelect,
 			onBeforeMatch,
 			onSelectedChange,
 			children,
@@ -191,6 +195,20 @@ const FieldCombobox = forwardRef<UHTMLComboboxElement, FieldComboboxProps>(
 		const innerRef = useRef<UHTMLComboboxElement>(null);
 		const onSelected = useRef(onSelectedChange);
 		onSelected.current = onSelectedChange; // Sync the latest onSelectedChange function
+
+		// Deprecated props
+		if (onAfterChange) {
+			onAfterSelect = onAfterChange;
+			console.warn(
+				`Combobox onAfterChange is deprecated, use onAfterSelect instead.`,
+			);
+		}
+		if (onBeforeChange) {
+			onBeforeSelect = onBeforeChange;
+			console.warn(
+				`Combobox onBeforeChange is deprecated, use onBeforeSelect instead.`,
+			);
+		}
 
 		useImperativeHandle(ref, () => innerRef.current as UHTMLComboboxElement); // Forward innerRef
 		useEffect(() => {
@@ -208,17 +226,18 @@ const FieldCombobox = forwardRef<UHTMLComboboxElement, FieldComboboxProps>(
 				else handleSelected?.([{ value, label }]);
 			};
 
-			self?.addEventListener("beforechange", handleChange);
-			return () => self?.removeEventListener("beforechange", handleChange);
+			self?.addEventListener("comboboxbeforeselect", handleChange);
+			return () =>
+				self?.removeEventListener("comboboxbeforeselect", handleChange);
 		}, [multiple, selected]);
 
 		return (
 			<u-combobox
 				{...toCustomElementProps({
 					"data-multiple": multiple,
-					onbeforechange: onBeforeChange,
-					onbeforematch: onBeforeMatch,
-					onafterchange: onAfterChange,
+					oncomboboxbeforeselect: onBeforeSelect,
+					oncomboboxbeforematch: onBeforeMatch,
+					oncomboboxafterselect: onAfterSelect,
 					ref: innerRef,
 					...props,
 				})}

--- a/designsystem/index.ts
+++ b/designsystem/index.ts
@@ -1,17 +1,18 @@
 // Expose custom elements not matching HTML elements
+
+export { UHTMLComboboxElement } from "@u-elements/u-combobox";
 export {
-	UHTMLTabsElement,
 	UHTMLTabElement,
 	UHTMLTabListElement,
 	UHTMLTabPanelElement,
+	UHTMLTabsElement,
 } from "@u-elements/u-tabs";
-export { UHTMLComboboxElement } from "@u-elements/u-combobox";
 
 // Expose API
 export { version } from "../package.json"; // Expose version to make it easier to debug
 export { analytics } from "./analytics/analytics";
-export { pagination } from "./pagination/pagination-helper";
 export { toggleAppExpanded } from "./app/app-observer";
+export { pagination } from "./pagination/pagination-helper";
 export * as styles from "./styles.module.css";
 
 // Load behaviours

--- a/designsystem/logo/logo.tsx
+++ b/designsystem/logo/logo.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { type JSX, forwardRef } from "react";
+import { forwardRef, type JSX } from "react";
 import type {
 	PolymorphicComponentPropWithRef,
 	PolymorphicRef,

--- a/designsystem/popover/popover-observer.ts
+++ b/designsystem/popover/popover-observer.ts
@@ -1,5 +1,5 @@
 import styles from "../styles.module.css";
-import { QUICK_EVENT, anchorPosition, attr, on, onLoaded } from "../utils";
+import { anchorPosition, attr, on, onLoaded, QUICK_EVENT } from "../utils";
 
 const CSS_POPOVER = styles.popover.split(" ")[0];
 let OPEN_POPOVERS = 0; // Speed up by only checking clicks if we have open popovers

--- a/designsystem/popover/popover.tsx
+++ b/designsystem/popover/popover.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { type JSX, forwardRef } from "react";
+import { forwardRef, type JSX } from "react";
 import type {
 	PolymorphicComponentPropWithRef,
 	PolymorphicRef,

--- a/designsystem/skeleton/skeleton.tsx
+++ b/designsystem/skeleton/skeleton.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { type JSX, forwardRef } from "react";
+import { forwardRef, type JSX } from "react";
 import type {
 	PolymorphicComponentPropWithRef,
 	PolymorphicRef,

--- a/designsystem/steps/steps.mdx
+++ b/designsystem/steps/steps.mdx
@@ -14,8 +14,8 @@ import * as stories from './steps.stories';
 - Bruk `data-color` for å endre farge på stegene
 <Canvas of={stories.Default} />
 
-## Retning
-- Bruk `data-state="complete"` for å endre retningen på stegene
+## Fullført
+- Bruk `data-state="complete"` for å få avhuking på alle stegene
 <Canvas of={stories.WithStateComplete} />
 
 ## Retning

--- a/designsystem/steps/steps.module.css
+++ b/designsystem/steps/steps.module.css
@@ -23,6 +23,7 @@
 		flex: 1;
 		position: relative;
 		text-decoration: none;
+		padding-inline: var(--mtds-4);
 	}
 
 	/*
@@ -177,7 +178,7 @@
 		flex: 1 0 100%;
 		min-height: calc(var(--mtdsc-steps-dot-size) * 2);
 		padding-block: 0 var(--mtdsc-steps-dot-size);
-		padding-left: calc(var(--mtdsc-steps-dot-size) + var(--mtdsc-steps-gap));
+		padding-inline: calc(var(--mtdsc-steps-dot-size) + var(--mtdsc-steps-gap)) 0;
 	}
 	.steps[data-direction]:not([data-direction="right"]) > li mark {
 		inset: 0;

--- a/designsystem/steps/steps.stories.tsx
+++ b/designsystem/steps/steps.stories.tsx
@@ -114,7 +114,7 @@ export const WithDirection: Story = {
 				<strong>
 					With <code>data-direction="right"</code>:
 				</strong>
-				<ol className={styles.steps} data-size="sm" data-direction="right">
+				<ol className={styles.steps} data-direction="right">
 					<li>
 						<mark>
 							<HeartIcon />
@@ -143,7 +143,7 @@ export const WithDirection: Story = {
 				<strong>
 					With <code>data-direction="down"</code>:
 				</strong>
-				<ol className={styles.steps} data-size="sm" data-direction="down">
+				<ol className={styles.steps} data-direction="down">
 					<li>
 						<mark>
 							<HeartIcon />
@@ -179,7 +179,7 @@ export const WithDirection: Story = {
 				<strong>
 					With <code>data-direction="up"</code>:
 				</strong>
-				<ol className={styles.steps} data-size="sm" data-direction="up">
+				<ol className={styles.steps} data-direction="up">
 					<li>
 						<mark>
 							<HeartIcon />

--- a/designsystem/tag/tag.module.css
+++ b/designsystem/tag/tag.module.css
@@ -38,8 +38,7 @@
 	.tag > svg {
 		flex-shrink: 0; /* Never shrkink icon */
 	}
-	.tag:not([data-icon], :has(svg))::before,
-	.tag[data-icon="true"]::before {
+	.tag:not([data-icon="none"], [data-icon="false"], :has(svg))::before {
 		background: currentcolor;
 		content: "";
 		flex-shrink: 0;

--- a/designsystem/tag/tag.tsx
+++ b/designsystem/tag/tag.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { type JSX, forwardRef } from "react";
+import { forwardRef, type JSX } from "react";
 import type {
 	PolymorphicComponentPropWithRef,
 	PolymorphicRef,

--- a/designsystem/typography/typography.tsx
+++ b/designsystem/typography/typography.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { type JSX, forwardRef } from "react";
+import { forwardRef, type JSX } from "react";
 import type {
 	PolymorphicComponentPropWithRef,
 	PolymorphicRef,

--- a/identitet/illustrations-generator/index.tsx
+++ b/identitet/illustrations-generator/index.tsx
@@ -7,7 +7,7 @@ import {
 	TShirtIcon,
 } from "@phosphor-icons/react";
 import { Fragment, useEffect, useRef, useState } from "react";
-import { Button, Card, Flex, Grid, Popover } from "../../designsystem/react";
+import { Button, Card, Flex, Popover } from "../../designsystem/react";
 import svg from "./index.svg?raw"; // Assuming all parts are exported from this file
 
 type Select = { value?: string; label: string; options: Option[] };
@@ -92,7 +92,7 @@ export function IllustrationsGenerator() {
 								{ICONS[key as keyof typeof ICONS] || <LegoSmileyIcon />}
 							</Button>
 							<Popover as="menu" id={`popover-${key}`} style={{ width: 300 }}>
-								{select.options.map(({ value, label, x, y, w, h }) => (
+								{select.options.map(({ value, label }) => (
 									<li key={value}>
 										<Button
 											// data-tooltip={label}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
 			"name": "@mattilsynet/design",
 			"version": "1.3.13",
 			"dependencies": {
-				"@u-elements/u-combobox": "^0.0.19",
-				"@u-elements/u-datalist": "^1.0.11",
+				"@u-elements/u-combobox": "^1.0.0",
+				"@u-elements/u-datalist": "^1.0.13",
 				"@u-elements/u-details": "^0.1.1",
 				"@u-elements/u-progress": "^0.0.5",
 				"@u-elements/u-tabs": "^0.0.9",
@@ -2649,15 +2649,15 @@
 			"license": "MIT"
 		},
 		"node_modules/@u-elements/u-combobox": {
-			"version": "0.0.19",
-			"resolved": "https://registry.npmjs.org/@u-elements/u-combobox/-/u-combobox-0.0.19.tgz",
-			"integrity": "sha512-hKG5FmD/qQ6i0cE+y6K/qCKhUt1eiFMmajoMBR6vdPVL4UjNOkjmaodFYM6cVWs5UFwwVlnjfK4BgLEVEWS/5Q==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@u-elements/u-combobox/-/u-combobox-1.0.0.tgz",
+			"integrity": "sha512-mPUbU2yaQpFL5FQlwtN/R9N+qCqO2GoUTAOZDP/P64pOJ2VRUY+AGfpWiGdOjm+VBokk3ufDZR2yuq3dAvfweg==",
 			"license": "MIT"
 		},
 		"node_modules/@u-elements/u-datalist": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/@u-elements/u-datalist/-/u-datalist-1.0.11.tgz",
-			"integrity": "sha512-Mc951aOtgMQ98mI+6KytZJRCkvE4bT4KIarLMLWGOmd/YO+Do6bd/AuRlBysQoryfWlYIt0Th4eA9rx1MPi6/w==",
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/@u-elements/u-datalist/-/u-datalist-1.0.13.tgz",
+			"integrity": "sha512-dm3ljVfbfYe3Heos3acbtEOpWM6IQDT+wtB9ay0JLd4KVDIgBE0ZX4UX+lvu+GKP9ohL0h6yDXlKoo9ADw6eiA==",
 			"license": "MIT"
 		},
 		"node_modules/@u-elements/u-details": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@mattilsynet/design",
-	"version": "1.3.13",
+	"version": "2.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mattilsynet/design",
-			"version": "1.3.13",
+			"version": "2.0.0",
 			"dependencies": {
 				"@u-elements/u-combobox": "^1.0.0",
 				"@u-elements/u-datalist": "^1.0.13",

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
 		"vite-plugin-dts": "^4.5.4"
 	},
 	"dependencies": {
-		"@u-elements/u-combobox": "^0.0.19",
-		"@u-elements/u-datalist": "^1.0.11",
+		"@u-elements/u-combobox": "^1.0.0",
+		"@u-elements/u-datalist": "^1.0.13",
 		"@u-elements/u-details": "^0.1.1",
 		"@u-elements/u-progress": "^0.0.5",
 		"@u-elements/u-tabs": "^0.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mattilsynet/design",
-	"version": "1.3.13",
+	"version": "2.0.0",
 	"type": "module",
 	"main": "./mtds/index.js",
 	"types": "./mtds/index.d.ts",


### PR DESCRIPTION
- ⚠️ **Breaking: `Field.Combobox` events renamed:**
  - `beforechange` => `comboboxbeforeselect` (React: `onBeforeChange` => `onBeforeSelect`)
  - `afterchange` => `comboboxafterselect` (React: `onAfterChange` => `onAfterSelect`)
  - `beforematch` => `comboboxbeforematch` (React: `onBeforeMatch` => `onBeforeMatch`)
- 🌟 Feat: `Alert` now supports `data-icon="none"`
- ✅ Fix: `App` no longer uses CSS selectors unsupported by Cypress w/Electron
- ✅ Fix: `Field.Combobox` correctly positions on first opening interaction