### PR TITLE
chore: update version to 2.2.6

### DIFF
--- a/.storybook/blocks.tsx
+++ b/.storybook/blocks.tsx
@@ -136,18 +136,7 @@ export function CssVariables({ component = "", exclude }: CssVariablesProps) {
 								!excludes.some((exclude) => name.includes(exclude)) && (
 									<tr key={name}>
 										<td>{name}</td>
-										<td>
-											<Flex data-align="center" data-gap="2">
-												{val.startsWith("#") && (
-													<Tag
-														data-icon="none"
-														data-size="sm"
-														style={{ aspectRatio: 1, background: val }}
-													/>
-												)}
-												{val}
-											</Flex>
-										</td>
+										<td>{val}</td>
 									</tr>
 								),
 						)}

--- a/design-tokens-build/mattilsynet.css
+++ b/design-tokens-build/mattilsynet.css
@@ -182,6 +182,11 @@ design-tokens: v1.5.1
   --ds-color-warning-base-contrast-default: #1E1A28;
   --ds-color-focus-inner: #ffffff;
   --ds-color-focus-outer: #3D3D3D;
+  --ds-color-charts-chart-a: #116e6b;
+  --ds-color-charts-chart-b: #cae8ca;
+  --ds-color-charts-chart-c: #b6d9f2;
+  --ds-color-charts-chart-d: #feecbe;
+  --ds-color-charts-chart-e: #fdd2c9;
   --ds-link-color-visited: #663299;
 
   color-scheme: light;
@@ -303,6 +308,11 @@ design-tokens: v1.5.1
   --ds-color-warning-base-contrast-default: #1E1A28;
   --ds-color-focus-inner: #ffffff;
   --ds-color-focus-outer: #3D3D3D;
+  --ds-color-charts-chart-a: #116e6b;
+  --ds-color-charts-chart-b: #cae8ca;
+  --ds-color-charts-chart-c: #b6d9f2;
+  --ds-color-charts-chart-d: #feecbe;
+  --ds-color-charts-chart-e: #fdd2c9;
   --ds-link-color-visited: #663299;
 
   color-scheme: light;
@@ -504,6 +514,11 @@ design-tokens: v1.5.1
   --ds-color-warning-base-contrast-default: #1B160E;
   --ds-color-focus-inner: #191A1D;
   --ds-color-focus-outer: #BBBEC3;
+  --ds-color-charts-chart-a: #116e6b;
+  --ds-color-charts-chart-b: #cae8ca;
+  --ds-color-charts-chart-c: #b6d9f2;
+  --ds-color-charts-chart-d: #feecbe;
+  --ds-color-charts-chart-e: #fdd2c9;
   --ds-link-color-visited: #b49acd;
 
   color-scheme: dark;
@@ -625,6 +640,11 @@ design-tokens: v1.5.1
   --ds-color-warning-base-contrast-default: #1B160E;
   --ds-color-focus-inner: #191A1D;
   --ds-color-focus-outer: #BBBEC3;
+  --ds-color-charts-chart-a: #116e6b;
+  --ds-color-charts-chart-b: #cae8ca;
+  --ds-color-charts-chart-c: #b6d9f2;
+  --ds-color-charts-chart-d: #feecbe;
+  --ds-color-charts-chart-e: #fdd2c9;
   --ds-link-color-visited: #b49acd;
 
   color-scheme: dark;

--- a/design-tokens/$themes.json
+++ b/design-tokens/$themes.json
@@ -44,7 +44,8 @@
       "_size.30": "f1b656cb38dff499335c93dec716e60deddee2d5",
       "_size.mode-font-size": "bc1f740a4f5e7b573b353df605a2980b8ca0e1e7",
       "_size.base": "debe379619b8f3757c3eb5a37798be2a8cc748a9",
-      "_size.step": "6c561863135e392c0df91dd5fb380f4ccc312769"
+      "_size.step": "6c561863135e392c0df91dd5fb380f4ccc312769",
+      "_size.unit": "222080d6d9e36a33ff46d645bd5de519effe6e07"
     }
   },
   {
@@ -92,7 +93,8 @@
       "_size.30": "f1b656cb38dff499335c93dec716e60deddee2d5",
       "_size.mode-font-size": "bc1f740a4f5e7b573b353df605a2980b8ca0e1e7",
       "_size.base": "debe379619b8f3757c3eb5a37798be2a8cc748a9",
-      "_size.step": "6c561863135e392c0df91dd5fb380f4ccc312769"
+      "_size.step": "6c561863135e392c0df91dd5fb380f4ccc312769",
+      "_size.unit": "222080d6d9e36a33ff46d645bd5de519effe6e07"
     }
   },
   {
@@ -140,7 +142,8 @@
       "_size.30": "f1b656cb38dff499335c93dec716e60deddee2d5",
       "_size.mode-font-size": "bc1f740a4f5e7b573b353df605a2980b8ca0e1e7",
       "_size.base": "debe379619b8f3757c3eb5a37798be2a8cc748a9",
-      "_size.step": "6c561863135e392c0df91dd5fb380f4ccc312769"
+      "_size.step": "6c561863135e392c0df91dd5fb380f4ccc312769",
+      "_size.unit": "222080d6d9e36a33ff46d645bd5de519effe6e07"
     }
   },
   {
@@ -404,7 +407,12 @@
       "mattilsynet.inverted.13": "a204603a17bd28c281cc010d41b54e969ba794f0",
       "mattilsynet.inverted.14": "3b1bf2f9f3cd0ca5352c4ddfcc9d090344ef84bd",
       "mattilsynet.inverted.15": "f0f3c9b9fb0ea4883d46432760aeaf43c98bf0cb",
-      "mattilsynet.inverted.16": "25810e559e12eedada87e531ff1ffddddbae384a"
+      "mattilsynet.inverted.16": "25810e559e12eedada87e531ff1ffddddbae384a",
+      "mattilsynet.charts.a": "7140f646a23ba4cf7791ab9332cba12700a2f1eb",
+      "mattilsynet.charts.b": "2905bdd122a8232992c3ce4345d1420ec40948e9",
+      "mattilsynet.charts.c": "32836fea55fbac4c361ea1048fc6d362b100f43c",
+      "mattilsynet.charts.d": "59af25001d79e7ddc5b574563b9091f4c31c2cee",
+      "mattilsynet.charts.e": "96ea0222c235856134ec4221129039ca7394e0c4"
     },
     "$figmaStyleReferences": {
       "global.blue.1": "S:158aa3202977fe372d0b47d1a7f4230e99582f8f,",
@@ -675,7 +683,12 @@
       "mattilsynet.inverted.13": "a204603a17bd28c281cc010d41b54e969ba794f0",
       "mattilsynet.inverted.14": "3b1bf2f9f3cd0ca5352c4ddfcc9d090344ef84bd",
       "mattilsynet.inverted.15": "f0f3c9b9fb0ea4883d46432760aeaf43c98bf0cb",
-      "mattilsynet.inverted.16": "25810e559e12eedada87e531ff1ffddddbae384a"
+      "mattilsynet.inverted.16": "25810e559e12eedada87e531ff1ffddddbae384a",
+      "mattilsynet.charts.a": "7140f646a23ba4cf7791ab9332cba12700a2f1eb",
+      "mattilsynet.charts.b": "2905bdd122a8232992c3ce4345d1420ec40948e9",
+      "mattilsynet.charts.c": "32836fea55fbac4c361ea1048fc6d362b100f43c",
+      "mattilsynet.charts.d": "59af25001d79e7ddc5b574563b9091f4c31c2cee",
+      "mattilsynet.charts.e": "96ea0222c235856134ec4221129039ca7394e0c4"
     },
     "$figmaStyleReferences": {
       "global.blue.1": "S:158aa3202977fe372d0b47d1a7f4230e99582f8f,",
@@ -934,6 +947,11 @@
       "color.warning.base-contrast-default": "7e94cb576efa314d79a456090f036a08d700bfbb",
       "color.focus.inner": "017f968dff7989ee881c4251d21cca040b45c0f2",
       "color.focus.outer": "be476510a8043d83922449b519eec2f31a09c67e",
+      "color.charts.chart-a": "f73514b8bdd633973528723f1f7955be074888b3",
+      "color.charts.chart-b": "acdc3a36b64608d96d8b615d1fe01589c56847d5",
+      "color.charts.chart-c": "78f6a3dbfe5ce41ce35e23208f8e963f8ea387eb",
+      "color.charts.chart-d": "223437fd3b08594806d1978b7c9e43fb4e6cd06a",
+      "color.charts.chart-e": "c45580427e5af88d226a04523a9b0f2405a9aa97",
       "link.color.visited": "20f24d40707f02b98dbd2c9ca375aa7aa59f8421",
       "opacity.disabled": "83a96f9215a743479bccca49977b10c5be8d9dea",
       "border-width.default": "7a5f3eb5e0bc43f6d9b11061b1bf727bf92f1d31",

--- a/design-tokens/primitives/modes/color-scheme/dark/mattilsynet.json
+++ b/design-tokens/primitives/modes/color-scheme/dark/mattilsynet.json
@@ -243,6 +243,29 @@
         "$value": "#081E21",
         "$description": "base-contrast-default"
       }
+    },
+    "charts": {
+      "a": {
+        "$type": "color",
+        "$value": "#116e6b"
+      },
+      "b": {
+        "$type": "color",
+        "$value": "#cae8ca"
+      },
+      "c": {
+        "$type": "color",
+        "$value": "#b6d9f2"
+      },
+      "d": {
+        "$type": "color",
+        "$value": "#feecbe"
+      },
+      "e": {
+        "$type": "color",
+        "$value": "#fdd2c9",
+        "$description": "\n"
+      }
     }
   }
 }

--- a/design-tokens/primitives/modes/color-scheme/light/mattilsynet.json
+++ b/design-tokens/primitives/modes/color-scheme/light/mattilsynet.json
@@ -245,6 +245,30 @@
         "$value": "#054449",
         "$description": "base-contrast-default"
       }
+    },
+    "charts": {
+      "a": {
+        "$type": "color",
+        "$value": "#116e6b",
+        "$description": "\n"
+      },
+      "b": {
+        "$type": "color",
+        "$value": "#cae8ca"
+      },
+      "c": {
+        "$type": "color",
+        "$value": "#b6d9f2"
+      },
+      "d": {
+        "$type": "color",
+        "$value": "#feecbe"
+      },
+      "e": {
+        "$type": "color",
+        "$value": "#fdd2c9",
+        "$description": "\n"
+      }
     }
   }
 }

--- a/design-tokens/semantic/color.json
+++ b/design-tokens/semantic/color.json
@@ -471,6 +471,28 @@
         "$type": "color",
         "$value": "{color.neutral.text-default}"
       }
+    },
+    "charts": {
+      "chart-a": {
+        "$type": "color",
+        "$value": "{mattilsynet.charts.a}"
+      },
+      "chart-b": {
+        "$type": "color",
+        "$value": "{mattilsynet.charts.b}"
+      },
+      "chart-c": {
+        "$type": "color",
+        "$value": "{mattilsynet.charts.c}"
+      },
+      "chart-d": {
+        "$type": "color",
+        "$value": "{mattilsynet.charts.d}"
+      },
+      "chart-e": {
+        "$type": "color",
+        "$value": "{mattilsynet.charts.e}"
+      }
     }
   },
   "link": {

--- a/designsystem/card/card.module.css
+++ b/designsystem/card/card.module.css
@@ -26,6 +26,9 @@
 	.card:is(label, button:enabled, button:not([aria-disabled="true"])) {
 		cursor: pointer;
 	}
+	.card:is(button) {
+		width: 100%;
+	}
 
 	.card:is(u-details, details):has(> :is(u-summary, summary):hover),
 	.card:is(:any-link, button, [role="button"]):hover {

--- a/designsystem/chart/chart-lines.ts
+++ b/designsystem/chart/chart-lines.ts
@@ -7,8 +7,8 @@ type Config = {
 	variant: string;
 };
 
-export function toLines(data: ChartData, { total, type, variant }: Config) {
-	const smoothing = Number.parseFloat(type || "10") || 0;
+export function toLines(data: ChartData, { total, variant }: Config) {
+	const smoothing = 0; // Number.parseFloat(type || "10") || 0;
 	const group = tag("div", { class: "axisGroup" });
 	data.slice(1).forEach(([, ...values]) => {
 		const lineContainer = tag("div", {

--- a/designsystem/chart/chart.css
+++ b/designsystem/chart/chart.css
@@ -231,24 +231,30 @@
 	stroke: var(--color);
 	stroke-linejoin: round;
 	stroke-linecap: round;
-	stroke-width: 3;
+	stroke-width: 1.5;
 	vector-effect: non-scaling-stroke;
 }
-.line {
-	filter: brightness(0.8) saturate(2); /* Ensure more contrast for line colors */
-}
+
 .lineShade {
 	stroke: none;
 	fill: var(--color);
 	opacity: 0.3;
 	mask: linear-gradient(to bottom, black, transparent);
 }
+
+.line,
+.linePoint,
+:host:has(.linePoint) .legend::before {
+	filter: brightness(0.8) saturate(2); /* Ensure more contrast for line colors */
+}
+
 .linePoint {
 	--size: var(--ds-size-3);
 	background-color: var(--color);
 	border-radius: var(--ds-border-radius-full);
 	border: var(--mtdsc-chart-border-width) solid var(--mtdsc-chart-border-color);
 	box-sizing: border-box;
+	filter: brightness(0.8) saturate(2);
 	height: var(--size);
 	margin: calc(var(--size) / -2);
 	padding: 0;

--- a/designsystem/chart/chart.mdx
+++ b/designsystem/chart/chart.mdx
@@ -30,7 +30,6 @@ import * as stories from './chart.stories';
 
 ## Linjediagram
 - Bruk `data-variant="line"` for linjediagram eller  `data-variant="area"` for fylt linjediagram
-- Bruk `data-variant="line-SMOOTHING` eller `data-variant="area-SMOOTHING"`, hvor `SMOOTHING` er et tall, for å endre hvor mye kurven skal jevnes ut (`10` er default)
 <Grid data-items="300"><Canvas of={stories.Line} /><Canvas of={stories.Area} /></Grid>
 
 ## Kakediagram

--- a/designsystem/chart/chart.module.css
+++ b/designsystem/chart/chart.module.css
@@ -5,19 +5,11 @@
 			var(--ds-color-border-subtle);
 		--mtdsc-chart-axis-gap: var(--ds-size-4);
 		--mtdsc-chart-border-width: var(--ds-border-width-default);
-		--mtdsc-chart-border-color: #054449; /*var(--ds-color-border-default);*/
-		--mtdsc-chart-color-base: #116e6b; /* var(--ds-color-base-default); */
-		--mtdsc-chart-color-success: #cae8ca; /*var(--ds-color-surface-active); */
-		--mtdsc-chart-color-info: #b6d9f2; /*var(--ds-color-info-surface-hover); */
-		--mtdsc-chart-color-warning: #feecbe; /*var(--ds-color-warning-surface-hover);*/
-		--mtdsc-chart-color-danger: #fdd2c9; /*var(--ds-color-danger-surface-active);*/
-		--mtdsc-chart-color-neutral: var(--ds-color-neutral-surface-tinted);
-		--mtdsc-chart-color-1: var(--mtdsc-chart-color-base);
-		--mtdsc-chart-color-2: var(--mtdsc-chart-color-success);
-		--mtdsc-chart-color-3: var(--mtdsc-chart-color-info);
-		--mtdsc-chart-color-4: var(--mtdsc-chart-color-warning);
-		--mtdsc-chart-color-5: var(--mtdsc-chart-color-danger);
-		--mtdsc-chart-color-6: var(--ds-color-neutral-surface-tinted);
+		--mtdsc-chart-color-1: var(--ds-color-charts-chart-a);
+		--mtdsc-chart-color-2: var(--ds-color-charts-chart-b);
+		--mtdsc-chart-color-3: var(--ds-color-charts-chart-c);
+		--mtdsc-chart-color-4: var(--ds-color-charts-chart-d);
+		--mtdsc-chart-color-5: var(--ds-color-charts-chart-e);
 	}
 	mtds-chart table {
 		border-collapse: collapse;

--- a/designsystem/chart/chart.stories.tsx
+++ b/designsystem/chart/chart.stories.tsx
@@ -141,6 +141,49 @@ export const Bar: Story = {
 	render: () => <mtds-chart data-variant="bar">{table}</mtds-chart>,
 };
 
+export const BarSingleDataset: Story = {
+	render: () => (
+		<mtds-chart data-variant="bar" data-aspect="3/1">
+			<table>
+				<thead>
+					<tr>
+						<th>Risikofordeling</th>
+						<th>J</th>
+						<th>F</th>
+						<th>M</th>
+						<th>A</th>
+						<th>M</th>
+						<th>J</th>
+						<th>J</th>
+						<th>A</th>
+						<th>S</th>
+						<th>O</th>
+						<th>N</th>
+						<th>D</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th>Slakt av laks</th>
+						<td data-tooltip="Januar: 10">10</td>
+						<td data-tooltip="Februar: 15">15</td>
+						<td data-tooltip="Mars: 25">25</td>
+						<td data-tooltip="April: 40">40</td>
+						<td data-tooltip="Mai: 10">10</td>
+						<td data-tooltip="Juni: 5">5</td>
+						<td data-tooltip="Juli: 15">15</td>
+						<td data-tooltip="August: 30">30</td>
+						<td data-tooltip="September: 20">20</td>
+						<td data-tooltip="Oktober: 25">25</td>
+						<td data-tooltip="November: 35">35</td>
+						<td data-tooltip="Desember: 55">55</td>
+					</tr>
+				</tbody>
+			</table>
+		</mtds-chart>
+	),
+};
+
 export const BarStacked: Story = {
 	render: () => <mtds-chart data-variant="bar-stacked">{table}</mtds-chart>,
 };
@@ -156,40 +199,6 @@ export const ColumnStacked: Story = {
 export const Line: Story = {
 	render: () => (
 		<mtds-chart data-variant="line">
-			<table>
-				<thead>
-					<tr>
-						<th>Risikofordeling</th>
-						<th>Q1</th>
-						<th>Q2</th>
-						<th>Q3</th>
-						<th>Q4</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<th>Large</th>
-						<td>30</td>
-						<td>40</td>
-						<td>20</td>
-						<td>60</td>
-					</tr>
-					<tr>
-						<th>Medium</th>
-						<td>10</td>
-						<td>20</td>
-						<td>40</td>
-						<td>50</td>
-					</tr>
-				</tbody>
-			</table>
-		</mtds-chart>
-	),
-};
-
-export const LineStraight: Story = {
-	render: () => (
-		<mtds-chart data-variant="line-0">
 			<table>
 				<thead>
 					<tr>

--- a/designsystem/chart/chart.tsx
+++ b/designsystem/chart/chart.tsx
@@ -23,9 +23,7 @@ export type ChartProps = React.ComponentPropsWithoutRef<"div"> & {
 		| "column-stacked"
 		| "doughnut"
 		| "line"
-		| "pie"
-		| `area-${number}`
-		| `line-${number}`;
+		| "pie";
 };
 
 export const Chart = forwardRef<HTMLDivElement, ChartProps>(function Chart(

--- a/designsystem/details/details.module.css
+++ b/designsystem/details/details.module.css
@@ -64,6 +64,7 @@
 		margin: 0;
 		padding: 0;
 		transition: rotate 0.2s ease-out;
+		height: 1lh; /* Align with first line */
 	}
 	.details[open] > :is(summary, u-summary)::before {
 		rotate: -180deg;
@@ -98,7 +99,7 @@
 		> :is(img, svg):first-child {
 		flex-shrink: 0; /* Prevent icon from shrinking */
 		width: var(--mtds-icon-size);
-		height: var(--mtds-icon-size);
+		height: 1lh; /* Align with first line */
 	}
 	.details[data-variant="card"] > :is(summary, u-summary)::before {
 		margin-inline-start: auto;

--- a/designsystem/map/map.module.css
+++ b/designsystem/map/map.module.css
@@ -1,5 +1,5 @@
 @layer mt.design {
 	.map {
-		font-size: inherit;
+		background: var(--ds-color-neutral-surface-tinted);
 	}
 }

--- a/designsystem/map/map.stories.tsx
+++ b/designsystem/map/map.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Map as OpenLayersMap, View } from "ol";
+import { fromLonLat } from "ol/proj";
 import { useEffect, useRef } from "react";
+import styles from "../styles.module.css";
+import { MtdsTile, Zoom } from "./map";
 import "../../node_modules/ol/ol.css";
-import { getTilesColor, getTilesGrascale } from "./map";
 
 const meta = {
 	title: "Designsystem/Map",
@@ -21,12 +23,15 @@ export const Default: Story = {
 
 		// Initialize the map when the component mounts
 		useEffect(() => {
-			if (!mapRef.current) return;
 			const map = new OpenLayersMap({
-				target: mapRef.current,
-				layers: [getTilesColor(), getTilesGrascale()],
-				view: new View({ center: [0, 0], zoom: 2 }),
+				target: mapRef.current || undefined,
+				layers: [
+					new MtdsTile("color", { visible: false }),
+					new MtdsTile("gray"),
+				],
+				view: new View({ center: fromLonLat([8.4689, 64]), zoom: 5 }),
 				controls: [
+					new Zoom(),
 					// new Zoom({
 					// 	zoomInTipLabel: "Zoom inn",
 					// 	zoomOutTipLabel: "Zoom ut",
@@ -39,6 +44,8 @@ export const Default: Story = {
 			return () => map.setTarget(undefined);
 		}, []);
 
-		return <div ref={mapRef} style={{ aspectRatio: 2 }} />;
+		return (
+			<div ref={mapRef} className={styles.map} style={{ aspectRatio: 2 }} />
+		);
 	},
 };

--- a/designsystem/map/map.ts
+++ b/designsystem/map/map.ts
@@ -1,77 +1,87 @@
-import { getTopLeft, getWidth } from "ol/extent";
+import { Control } from "ol/control";
 import { Tile } from "ol/layer";
-import { get as getProjection } from "ol/proj";
-import { OSM, WMTS } from "ol/source";
-import { WMTS as WMTSTileGrid } from "ol/tilegrid";
+import { OSM, XYZ } from "ol/source";
+import type TileSource from "ol/source/Tile";
+import { on, tag } from "../utils";
 
-// import { Zoom } from "ol/control";
-// import { tag } from "../utils";
+export class Zoom extends Control {
+	/**
+	 * @param {Object} [options] Control options.
+	 */
+	constructor({ target }: Record<string, string> = {}) {
+		const element = tag("div", {
+			style: "position: absolute; user-select: none",
+		});
+		const button = element.appendChild(tag("button", {}, "N"));
 
-// class RotateNorthControl extends Control {
-// 	/**
-// 	 * @param {Object} [opt_options] Control options.
-// 	 */
-// 	constructor(opt_options?: Record<string, string>) {
-// 		const options = opt_options || {};
+		super({ element, target });
+		on(button, "click", this.handleRotateNorth.bind(this), false);
+	}
+	handleRotateNorth() {
+		this.getMap()?.getView().setRotation(0);
+	}
+}
 
-// 		const button = tag("button");
-// 		button.innerHTML = "N";
+export type MtdsTileTypes = "color" | "gray" | "gray-subtle";
+export type MtdsTileOptions = ConstructorParameters<typeof Tile>[0];
+export class MtdsTile extends Tile {
+	constructor(type: MtdsTileTypes, options?: MtdsTileOptions) {
+		let source: TileSource;
 
-// 		const element = tag("div", {
-// 			class: "rotate-north ol-unselectable ol-control",
-// 		});
-// 		element.appendChild(button);
+		if (type === "gray") {
+			source = new XYZ({
+				url: "https://cache.kartverket.no/v1/wmts/1.0.0/topograatone/default/webmercator/{z}/{y}/{x}.png",
+				attributions: "© Kartverket",
+			});
+		} else if (type === "gray-subtle") {
+			source = new XYZ({
+				url: "https://{a-c}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
+				attributions: "© CARTO",
+			});
+		} else {
+			source = new OSM({ attributions: "© OpenStreetMap" });
+		}
+
+		super({ source, ...options });
+	}
+}
+
+// export class MapGray extends Tile {
+// 	constructor() {
+// 		const projection = getProjection("EPSG:3857");
+// 		if (!projection) throw new Error("Projection not found");
+
+// 		const projectionExtent = projection.getExtent();
+// 		const size = getWidth(projectionExtent) / 256;
+// 		const resolutions = new Array(19);
+// 		const matrixIds = new Array(19);
+
+// 		// Generate resolutions and matrixIds arrays for this WMTS
+// 		for (let z = 0; z < 19; ++z) {
+// 			resolutions[z] = size / 2 ** z;
+// 			matrixIds[z] = z;
+// 		}
 
 // 		super({
-// 			element: element,
-// 			target: options.target,
+// 			opacity: 0.75,
+// 			properties: { name: "Kartverket", type: "baseLayer" },
+// 			visible: false,
+// 			source: new WMTS({
+// 				attributions: "© Kartverket",
+// 				// url: "https://cache.kartverket.no/v1/wmts/1.0.0/topograatone/default/", // Does not respont at the moment
+// 				url: "https://cache.kartverket.no/v1/service",
+// 				format: "image/png",
+// 				layer: "topograatone",
+// 				// matrixSet: "webmercator", // Does not respont at the moment
+// 				matrixSet: "utm33n",
+// 				style: "default",
+// 				wrapX: true,
+// 				tileGrid: new WMTSTileGrid({
+// 					origin: getTopLeft(projectionExtent),
+// 					resolutions,
+// 					matrixIds,
+// 				}),
+// 			}),
 // 		});
-
-// 		button.addEventListener("click", this.handleRotateNorth.bind(this), false);
-// 	}
-
-// 	handleRotateNorth() {
-// 		this.getMap()?.getView().setRotation(0);
 // 	}
 // }
-
-export const getTilesColor = () =>
-	new Tile({
-		source: new OSM({ attributions: "© OpenStreetMap-contributors" }),
-		properties: { name: "OpenStreetMap" },
-		visible: true,
-	});
-
-export const getTilesGrascale = () => {
-	const projection = getProjection("EPSG:3857");
-	if (!projection) throw new Error("Projection not found");
-
-	const projectionExtent = projection.getExtent();
-	const size = getWidth(projectionExtent) / 256;
-	const resolutions = new Array(19);
-	const matrixIds = new Array(19);
-	// generate resolutions and matrixIds arrays for this WMTS
-	for (let z = 0; z < 19; ++z) {
-		resolutions[z] = size / 2 ** z;
-		matrixIds[z] = z;
-	}
-	return new Tile({
-		opacity: 0.75,
-		properties: { name: "Kartverket Gr...", type: "baseLayer" },
-		visible: false,
-		source: new WMTS({
-			attributions: "© Kartverket",
-			url: "https://cache.kartverket.no/v1/wmts/1.0.0/topograatone/default/",
-			layer: "topograatone",
-			matrixSet: "webmercator",
-			format: "image/png",
-			tileGrid: new WMTSTileGrid({
-				origin: getTopLeft(projectionExtent),
-				resolutions: resolutions,
-				matrixIds: matrixIds,
-			}),
-			style: "default",
-			wrapX: true,
-		}),
-	});
-};

--- a/designsystem/popover/popover-observer.ts
+++ b/designsystem/popover/popover-observer.ts
@@ -59,14 +59,15 @@ function handlePopoverLinkClick(event: Event) {
 			(open as HTMLElement).hidePopover();
 
 	if (pop && el) {
-		event.preventDefault(); // Prevent browser popover API
 		const action = attr(el, "popovertargetaction");
 		const open = action === "show" || (action === "hide" ? false : undefined);
 
 		// Popover can be disconneted by click handler deeper down in the DOM three before reaching document
 		if (el instanceof HTMLButtonElement && !action && pop.contains(el)) return; // Require "popovertargetaction" attribute to make buttons inside popover toggle
-		if (pop instanceof HTMLElement && pop.isConnected && pop.togglePopover)
+		if (pop instanceof HTMLElement && pop.isConnected && pop.togglePopover) {
+			event.preventDefault(); // Prevent browser popover API since we are doing it ourselves
 			pop.togglePopover(open);
+		}
 	}
 }
 

--- a/designsystem/styles.module.css
+++ b/designsystem/styles.module.css
@@ -22,6 +22,7 @@
 @import url("./layout/layout.module.css");
 @import url("./link/link.module.css");
 @import url("./logo/logo.module.css");
+@import url("./map/map.module.css");
 @import url("./pagination/pagination.module.css");
 @import url("./popover/popover.module.css");
 @import url("./progress/progress.module.css");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@mattilsynet/design",
-	"version": "2.2.5",
+	"version": "2.2.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mattilsynet/design",
-			"version": "2.2.5",
+			"version": "2.2.6",
 			"dependencies": {
 				"@floating-ui/dom": "^1.7.4",
 				"@u-elements/u-combobox": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mattilsynet/design",
-	"version": "2.2.5",
+	"version": "2.2.6",
 	"type": "module",
 	"main": "./mtds/index.js",
 	"types": "./mtds/index.d.ts",


### PR DESCRIPTION
- ✅ Fix: `Popover` less aggressively takes over buttons
- ✅ Fix: `Chart` colors moved to figma compatible tokens
- ✅ Fix: `Details` with `data-variant="card"` now correctly aligns icon in summary also when font size changes