### PR TITLE
chore: update version to 3.2.2

### DIFF
--- a/designsystem/tabs/tabs.tsx
+++ b/designsystem/tabs/tabs.tsx
@@ -1,34 +1,35 @@
-import type * as DS from "@digdir/designsystemet-web";
+import type * as UTabs from "@u-elements/u-tabs"; // TMP Using u-tabs while waiting for https://github.com/digdir/designsystemet/pull/4821
 import { forwardRef } from "react";
 import type { CustomReactElementProps } from "../react-types";
 import styles from "../styles.module.css";
 import { toCustomElementProps } from "../utils";
 
-export type TabsProps = CustomReactElementProps<DS.DSTabsElement>;
-const TabsComp = forwardRef<DS.DSTabsElement, TabsProps>(
+export type TabsProps = CustomReactElementProps<UTabs.UHTMLTabsElement>;
+const TabsComp = forwardRef<UTabs.UHTMLTabsElement, TabsProps>(
 	function Tabs(props, ref) {
-		return <ds-tabs ref={ref} {...toCustomElementProps(props, styles.tabs)} />;
+		return <u-tabs ref={ref} {...toCustomElementProps(props, styles.tabs)} />;
 	},
 );
 
-export type TabsListProps = CustomReactElementProps<DS.DSTabListElement>;
-const TabsList = forwardRef<DS.DSTabListElement, TabsListProps>(
+export type TabsListProps = CustomReactElementProps<UTabs.UHTMLTabListElement>;
+const TabsList = forwardRef<UTabs.UHTMLTabListElement, TabsListProps>(
 	function TabsList(props, ref) {
-		return <ds-tablist ref={ref} {...toCustomElementProps(props)} />;
+		return <u-tablist ref={ref} {...toCustomElementProps(props)} />;
 	},
 );
 
-export type TabsPanelProps = CustomReactElementProps<DS.DSTabPanelElement>;
-const TabsPanel = forwardRef<DS.DSTabPanelElement, TabsPanelProps>(
+export type TabsPanelProps =
+	CustomReactElementProps<UTabs.UHTMLTabPanelElement>;
+const TabsPanel = forwardRef<UTabs.UHTMLTabPanelElement, TabsPanelProps>(
 	function TabsPanel(props, ref) {
-		return <ds-tabpanel ref={ref} {...toCustomElementProps(props)} />;
+		return <u-tabpanel ref={ref} {...toCustomElementProps(props)} />;
 	},
 );
 
-export type TabsTabProps = CustomReactElementProps<DS.DSTabElement>;
-const TabsTab = forwardRef<DS.DSTabElement, TabsTabProps>(
+export type TabsTabProps = CustomReactElementProps<UTabs.UHTMLTabElement>;
+const TabsTab = forwardRef<UTabs.UHTMLTabElement, TabsTabProps>(
 	function TabsTab(props, ref) {
-		return <ds-tab ref={ref} {...toCustomElementProps(props)} />;
+		return <u-tab ref={ref} {...toCustomElementProps(props)} />;
 	},
 );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@mattilsynet/design",
-	"version": "3.2.1",
+	"version": "3.2.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mattilsynet/design",
-			"version": "3.2.1",
+			"version": "3.2.2",
 			"dependencies": {
 				"@digdir/designsystemet-web": "^1.13.3",
 				"@u-elements/u-combobox": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mattilsynet/design",
-	"version": "3.2.1",
+	"version": "3.2.2",
 	"type": "module",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
- ✅  Fix: `Tabs` now respects both `aria-controls` and `aria-selected` on initial render - also in React