### PR TITLE
chore: update version to 3.2.7

### DIFF
--- a/designsystem/validation/validation-observer.ts
+++ b/designsystem/validation/validation-observer.ts
@@ -64,10 +64,10 @@ const handleValidations = (event: Event) => {
 	invalid.focus(); // Only move focus to first invalid field if validate was true
 };
 
-// Hide related validations adain when typing
+// Hide related validations again when typing
 const handleInput = ({ target }: Event) => {
 	const input = target as HTMLInputElement;
-	if (isValidationForm(input.form)) return;
+	if (!isValidationForm(input.form)) return; // Skip if not in a validation form
 	for (const el of getValidations(input.closest("fieldset") || getField(input)))
 		attr(el, "hidden", "");
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@mattilsynet/design",
-	"version": "3.2.6",
+	"version": "3.2.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mattilsynet/design",
-			"version": "3.2.6",
+			"version": "3.2.7",
 			"dependencies": {
 				"@digdir/designsystemet-web": "^1.14.0",
 				"@u-elements/u-progress": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mattilsynet/design",
-	"version": "3.2.6",
+	"version": "3.2.7",
 	"type": "module",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
- ✅ Fix: `Validation` now stays visible when typing inside a `form` without `data-validation` 