### PR TITLE
chore: update version to 3.3.2

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -37,7 +37,7 @@
    */
   .sidebar-container { color: rgb(5, 68, 73) }
   .sidebar-container .sidebar-header a { font-size: 1.25rem } /* Larger title in sidebar */
-  .sidebar-container .sidebar-item :is(a, button) { align-items: center; font: inherit; font-weight: 400 }
+  .sidebar-container .sidebar-item :is(a, button) { align-items: center; font: inherit; font-weight: 400; white-space: pre }
   .sidebar-container .sidebar-item a { gap: 0 }
   .sidebar-container .sidebar-item:hover { background: #E2F1DF }
   .sidebar-container .sidebar-item,
@@ -48,8 +48,8 @@
     letter-spacing: 0;
     line-height: 1.5;
     text-transform: none;
- 
   }
+  .sidebar-container .search-result-item--label span { text-overflow: clip }
 
   .sidebar-container .search-result-item:is([data-id$="--default"], [data-id$="--docs"]) .search-result-item--label > :first-child { display: none }
   .sidebar-container .search-result-item:not([data-id$="--docs"], [data-id$="--default"]) .search-result-item--label > :first-child,

--- a/designsystem/logo/logo.module.css
+++ b/designsystem/logo/logo.module.css
@@ -102,6 +102,7 @@
 	.logo:not(:empty):not(:has(svg)) {
 		--_mtdsc-logo-indent: calc(var(--_mtdsc-logo-icon-size) + 0.94em);
 		height: auto;
+		padding-bottom: 1px; /* Fixes a 1px Safari text cutting when using mask with text */
 		line-height: 1.05;
 
 		&::before {

--- a/designsystem/logo/logo.stories.tsx
+++ b/designsystem/logo/logo.stories.tsx
@@ -4,6 +4,9 @@ import { Logo } from "../react";
 import styles from "../styles.module.css";
 
 const meta = {
+	id: "designsystem-logo",
+	// TODO: Hide keywords-hack with wide spaces:
+	// "Designsystem/Logo \u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000}\u{3000} symbol ikon",
 	title: "Designsystem/Logo",
 	parameters: {
 		layout: "fullscreen",
@@ -57,9 +60,7 @@ export const React: Story = {
 			</Logo>
 			<Logo as="h1" />
 			<Logo href="/" data-env="test">
-				Helse
-				<wbr />
-				sertifikat
+				Servering
 			</Logo>
 			<Logo href="/" data-env="test">
 				<PlantIcon weight="fill" />
@@ -100,7 +101,7 @@ export const WithSubbrandEnglish: Story = {
 export const WithSubbrandEnvironment: Story = {
 	render: () => (
 		<a className={styles.logo} href="/" lang="en" data-env="test">
-			Sanitary certificate status
+			Servering
 		</a>
 	),
 };

--- a/designsystem/table/table-observer.ts
+++ b/designsystem/table/table-observer.ts
@@ -2,9 +2,10 @@ import { attr, debounce, isBrowser, onHotReload, onMutation } from "../utils";
 
 const MOBILE = new WeakSet();
 const TABLES = isBrowser() ? document.getElementsByTagName("table") : [];
-const RESIZER = isBrowser()
-	? new ResizeObserver(debounce(handleResize, 200))
-	: null;
+const RESIZER =
+	isBrowser() && window.ResizeObserver // Check for ResizeObserver support, as it's not available in all environments (e.g., JSDOM)
+		? new ResizeObserver(debounce(handleResize, 200))
+		: null;
 
 function handleResize(
 	entries: Pick<ResizeObserverEntry, "target" | "contentRect">[],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@mattilsynet/design",
-	"version": "3.3.1",
+	"version": "3.3.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mattilsynet/design",
-			"version": "3.3.1",
+			"version": "3.3.2",
 			"dependencies": {
 				"@digdir/designsystemet-web": "^1.15.0",
 				"@u-elements/u-progress": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mattilsynet/design",
-	"version": "3.3.1",
+	"version": "3.3.2",
 	"type": "module",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
- ✅ Fix: `Logo` fixes pixel issue in Safari when typing `g` in a subbrand
- ✅ Fix: `Table` with `data-mobile` now plays nice with `jsdom` testing environments