### PR TITLE
chore: update version to 3.3.4

### DIFF
--- a/designsystem/table/table-observer.ts
+++ b/designsystem/table/table-observer.ts
@@ -25,9 +25,9 @@ function handleResize(
 function handleTableMobile() {
 	for (const target of TABLES)
 		if (target.hasAttribute("data-mobile")) {
-			const ths = Array.from(target.tHead?.rows[0]?.cells || [], (th) =>
-				th.innerText.trim(),
-			);
+			const ths = Array.from(target.tHead?.rows[0]?.cells || [], (th) => {
+				return (th.innerText ?? th.textContent).trim(); // Fallback to textContent if innerText is not supported (e.g., in JSDOM)
+			});
 
 			if (!MOBILE.has(target)) {
 				MOBILE.add(target);

--- a/designsystem/table/table-observer.ts
+++ b/designsystem/table/table-observer.ts
@@ -26,7 +26,7 @@ function handleTableMobile() {
 	for (const target of TABLES)
 		if (target.hasAttribute("data-mobile")) {
 			const ths = Array.from(target.tHead?.rows[0]?.cells || [], (th) => {
-				return (th.innerText ?? th.textContent).trim(); // Fallback to textContent if innerText is not supported (e.g., in JSDOM)
+				return (th.innerText ?? th.textContent)?.trim() || ""; // Fallback to textContent if innerText is not supported (e.g., in JSDOM)
 			});
 
 			if (!MOBILE.has(target)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@mattilsynet/design",
-	"version": "3.3.3",
+	"version": "3.3.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mattilsynet/design",
-			"version": "3.3.3",
+			"version": "3.3.4",
 			"dependencies": {
 				"@digdir/designsystemet-web": "^1.15.0",
 				"@u-elements/u-progress": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mattilsynet/design",
-	"version": "3.3.3",
+	"version": "3.3.4",
 	"type": "module",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
- ✅ Fix: `Table` is now JSDOM test environment friendly (previously used unsupported `.innerText`)