### PR TITLE
chore: update version to 3.3.6

### DIFF
--- a/designsystem/button/button.module.css
+++ b/designsystem/button/button.module.css
@@ -3,7 +3,7 @@
 		composes: ds-button from "@digdir/designsystemet-css";
 		/* TODO Digdir: add --dsc-button-border-radius */
 
-		flex-shrink: 0; /* If placed in flex */
+		flex-shrink: 0; /* TODO Digdir: If placed in flex */
 		max-width: 100%;
 		text-align: center;
 		transition-duration: 0.2s;

--- a/designsystem/print/print.module.css
+++ b/designsystem/print/print.module.css
@@ -54,7 +54,8 @@
 	break-before: page;
 }
 .print[data-size="sm"],
-.print [data-size="sm"] {
+.print[data-size="xs"][class*="heading"],
+.print [data-size="sm"]:not([class*="heading"]) {
 	font-size: var(--mtdsc-print-font-sm);
 }
 

--- a/designsystem/print/print.stories.tsx
+++ b/designsystem/print/print.stories.tsx
@@ -1,6 +1,15 @@
 import { CodeIcon, PrinterIcon } from "@phosphor-icons/react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Button, Grid, Heading, Print, Prose, Table } from "../react";
+import {
+	Button,
+	Grid,
+	Heading,
+	Ingress,
+	Muted,
+	Print,
+	Prose,
+	Table,
+} from "../react";
 import styles from "../styles.module.css";
 import css from "../styles.module.css?inline";
 
@@ -834,6 +843,41 @@ export const Vedtak: Story = {
 					</tbody>
 				</table>
 			</section>
+		</div>
+	),
+};
+
+export const Overskrifter: Story = {
+	render: () => (
+		<div id="my-print">
+			<style>
+				{`${css}:root {
+					--mtdsc-print-office: 'hovedkontoret';
+					--mtdsc-print-department: 'avdeling brukerdialog og kommunikasjon';
+        }`}
+			</style>
+			<Print as={Prose}>
+				<Heading data-size="2xl">Heading data-size="2xl"</Heading>
+				<p>Text</p>
+				<Heading data-size="xl">Heading data-size="xl"</Heading>
+				<p>Text</p>
+				<Heading data-size="lg">Heading data-size="lg"</Heading>
+				<p>Text</p>
+				<Heading data-size="md">Heading data-size="md"</Heading>
+				<p>Text</p>
+				<Heading data-size="sm">Heading data-size="sm"</Heading>
+				<p>Text</p>
+				<Heading data-size="xs">Heading data-size="xs"</Heading>
+				<p>Text</p>
+				<Heading data-size="2xs">Heading data-size="2xs"</Heading>
+				<p>Text</p>
+				<p>
+					<Ingress>Ingress</Ingress>
+				</p>
+				<p>
+					<Muted>Muted</Muted>
+				</p>
+			</Print>
 		</div>
 	),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@mattilsynet/design",
-	"version": "3.3.5",
+	"version": "3.3.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mattilsynet/design",
-			"version": "3.3.5",
+			"version": "3.3.6",
 			"dependencies": {
 				"@digdir/designsystemet-web": "^1.15.0",
 				"@u-elements/u-progress": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mattilsynet/design",
-	"version": "3.3.5",
+	"version": "3.3.6",
 	"type": "module",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
- ✅ Fix: `Print` now better aligns heading sizes