### PR TITLE
chore: update version to 3.4.4

### DIFF
--- a/designsystem/chip/chip.module.css
+++ b/designsystem/chip/chip.module.css
@@ -22,13 +22,13 @@
 		border-radius: var(--dsc-chip-border-radius--checkbox-input);
 	}
 
+	/* We want light version of removable chips, Digdir has a dark version */
 	.chip[data-removable] {
 		background: var(--dsc-chip-background);
 		border-color: var(--dsc-chip-border-color);
 		color: var(--dsc-chip-color);
-		padding-right: var(--ds-size-1);
 	}
 	.chip[data-removable]:hover::after {
-		mask-image: var(--mtds-icon-close--filled);
+		--dsc-chip-icon-url: var(--mtds-icon-close--filled);
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@mattilsynet/design",
-	"version": "3.4.2",
+	"version": "3.4.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mattilsynet/design",
-			"version": "3.4.2",
+			"version": "3.4.4",
 			"dependencies": {
 				"@digdir/designsystemet-web": "^1.18.0",
 				"@u-elements/u-progress": "1.0.1",
@@ -3533,9 +3533,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mattilsynet/design",
-	"version": "3.4.3",
+	"version": "3.4.4",
 	"type": "module",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
- ✅ Fix: `Chip` with `data-variant="removable"` now has correct padding