### PR TITLE
fix: drop icon on firefox

### DIFF
--- a/designsystem/input/input.module.css
+++ b/designsystem/input/input.module.css
@@ -84,6 +84,12 @@
 			opacity: 0;
 			width: var(--ds-size-6);
 		}
+
+		@supports not selector(::-webkit-calendar-picker-indicator) {
+            .input[type="date"] {
+                background-image: none;
+            }
+		}
 	}
 
 	.input[data-variant="inline"]:not([type="radio"], [type="checkbox"]) {


### PR DESCRIPTION
﻿﻿After:
<img width="234" height="135" alt="image" src="https://github.com/user-attachments/assets/941f98fa-f59c-41f5-bcfe-3195cfc5132c" />

Before:
<img width="234" height="135" alt="image" src="https://github.com/user-attachments/assets/98920b22-54e3-4cab-83a6-64cdf4971faa" />

This is somewhat unelegant, as it drops our icon and shows firefoxs default. Oposite of Chrome. However it dosn't seem like we have a stable way of targeting that icon, and this seems like the least intrusive solution. And it will only be visible for use dozen firefox users.
